### PR TITLE
Fixed displaying null image

### DIFF
--- a/src/commands/basic/AvatarCommand.ts
+++ b/src/commands/basic/AvatarCommand.ts
@@ -23,10 +23,10 @@ class AvatarCommand {
     ) {
         const embed = info(interaction.client, "「看來這就是你要的呢...」");
         if (target)
-            embed.setImage(target.avatarURL({ extension: "png", size: 1024 }));
+            embed.setImage(target.displayAvatarURL({ extension: "png", size: 1024 }));
         else
             embed.setImage(
-                interaction.user.avatarURL({
+                interaction.user.displayAvatarURL({
                     extension: "png",
                     size: 1024,
                 })


### PR DESCRIPTION
## Changes
+ [`8764f2c`](https://github.com/ppodds/YueTS/commit/8764f2c5c83f64515c4f4bace4c0c5dd5426a595) - Fixed #412 

## Explanation
[`User#avatarURL`](https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=avatarURL) returns the users avatar url if it's existent. If it doesn't it returns `null`.
[`User#displayAvatarURL`](https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=displayAvatarURL) returns the users avatar. if the user does not have an avatar, it returns the [`User#defaultAvatarURL`](https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=defaultAvatarURL)